### PR TITLE
use nightly rust to compile wasmi

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-12-14"


### PR DESCRIPTION
The nightly version of Rust is required to compile the wasmi submodule. I added a rust-toolchain.toml file to ensure the use of the nightly version.

```sh
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> wasmi/specs/src/lib.rs:1:1
  |
1 | #![feature(trait_alias)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^
```